### PR TITLE
Add dotnet dependency to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
     - Make sure you have the [C#](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp) extension
 - [Git](https://git-scm.com/)
 - [NPM](https://www.npmjs.com/get-npm)
+- [.NET Core 3.1](https://dotnet.microsoft.com/download)
 
 # Getting the code
 


### PR DESCRIPTION
I realised I'd left out this dependency as a separate install isn't necessary when using Visual Studio. I'm setting up on my mac now so should hopefully spot if there are any other similar missing dependencies.